### PR TITLE
Add sphinx.ext.autosectionlabel

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ import metadata  # NOQA
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode'


### PR DESCRIPTION
Add sphinx.ext.autosectionlabel to make it easier to refer to sections; see http://www.sphinx-doc.org/en/stable/ext/autosectionlabel.html for details.