### PR TITLE
Base template docs

### DIFF
--- a/docs/base-email-template.rst
+++ b/docs/base-email-template.rst
@@ -1,0 +1,21 @@
+Base Template Documentation
+===========================
+
+Variables Used
+--------------
+``is_html_email``
+    ``True`` is the content is HTML, ``False`` otherwise.
+
+
+Blocks Defined
+--------------
+These can be overridden by templates that inherit from the base.
+
+``content``
+    The content for the email.
+
+    Example content can be found at https://github.com/leemunroe/responsive-html-email-template/blob/c12462fe223858f4d8bf9265453f7f1776640976/email.html#L289-L307
+``preheader``
+    The contents of a ``<span>`` with a ``class`` of ``preheader``, which some email clients will show as a preview.
+``title``
+    The HTML title of the email (not the subject line).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ import metadata  # NOQA
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode'

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -47,3 +47,7 @@ If you want to work on documentation, you can run the development
 documentation server with::
 
     python setup.py devdocs
+
+Template Information
+--------------------
+:ref:`Base Template Documentation`


### PR DESCRIPTION
Adds basic information about the base email template. https://github.com/18F/django-email-pal/pull/15 should be merged first.