### PR TITLE
Add settings.SENDABLE_EMAILS.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,12 +26,12 @@ from GitHub for now::
 Required settings
 ~~~~~~~~~~~~~~~~~
 
-Add ``emailpal`` to your ``INSTALLED_APPS`` setting, e.g.:
+Add ``emailpal.apps.EmailPalConfig`` to your ``INSTALLED_APPS`` setting, e.g.:
 
 .. code-block:: python
 
    INSTALLED_APPS = (
        # ...
-       'emailpal',
+       'emailpal.apps.EmailPalConfig',
        # ...
    )

--- a/emailpal/apps.py
+++ b/emailpal/apps.py
@@ -1,0 +1,33 @@
+from typing import List  # NOQA
+from django.apps import AppConfig
+from django.conf import settings
+from django.utils.module_loading import import_string
+from django.core.exceptions import ImproperlyConfigured
+from django.core.signals import setting_changed
+
+from .sendable_email import SendableEmail
+
+
+class EmailPalConfig(AppConfig):
+    name = 'emailpal'
+    verbose_name = 'Email Pal'
+
+    sendable_emails = []  # type: List[SendableEmail]
+
+    def configure_sendable_emails(self):
+        self.sendable_emails[:] = []
+        for name in getattr(settings, 'SENDABLE_EMAILS', []):
+            cls = import_string(name)
+            if not issubclass(cls, SendableEmail):
+                raise ImproperlyConfigured(
+                    '{} must be a subclass of SendableEmail'.format(name)
+                )
+            self.sendable_emails.append(cls)
+
+    def _on_setting_changed(self, setting=None, enter=None, **kwargs):
+        if setting == 'SENDABLE_EMAILS':
+            self.configure_sendable_emails()
+
+    def ready(self):
+        self.configure_sendable_emails()
+        setting_changed.connect(self._on_setting_changed)

--- a/emailpal/tests/conftest.py
+++ b/emailpal/tests/conftest.py
@@ -7,7 +7,7 @@ APP_DIR = MY_DIR.parent
 SETTINGS_DICT = {
     'BASE_DIR': str(APP_DIR),
     'INSTALLED_APPS': (
-        'emailpal',
+        'emailpal.apps.EmailPalConfig',
     ),
     'DATABASES': {
         'default': {

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -38,7 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'emailpal',
+    'emailpal.apps.EmailPalConfig',
     'example',
 ]
 


### PR DESCRIPTION
This adds a `settings.SENDABLE_EMAILS` setting which can be set to a list of import strings that point to `SendableEmail` subclasses, fixing #11.

In the future we can expand on this to provide more auto-discovery options, but this seems OK for now.

